### PR TITLE
Fix skipvalue for maps and arrays.

### DIFF
--- a/src/types/maps.jl
+++ b/src/types/maps.jl
@@ -73,14 +73,18 @@ end
 
 function skipvalue(B::Binary, MT::MapType, ::Type{A}, buf, pos, buflen, opts) where {A <: AbstractDict{K, V}} where {K, V}
     while true
+        # read the count of elements in the block
         len, pos = readvalue(B, long, Int, buf, pos, buflen, opts)
         if len == 0
+            # no more elements
             break
         elseif len < 0
+            # the block includes its size in bytes: read it and skip that much data
             sz, pos = readvalue(B, long, Int, buf, pos, buflen, opts)
             pos += sz
         else
-            for i = 1:-len
+            # skip each element individually
+            for i = 1:len
                 pos = skipvalue(B, string, K, buf, pos, buflen, opts)
                 pos = skipvalue(B, MT.values, V, buf, pos, buflen, opts)
             end


### PR DESCRIPTION
As is, I was unable to read a pre-existing Avro object file without crashing my julia session. I fired up the debugger. The issue appeared to be manifesting as negative numbers showing for some relevant stream positions. I was unable to actually narrow down the issue further, though, until I turned off inlining for the julia session. That's when I was able to step into this particular method and saw some logic that didn't seem right. Removing the negation allowed my object file to be read without issue.

I would have also contributed a test case, but the data is proprietary. It might be worthwhile, though, to generate an object file or two with, say, pyavro and make a few tests to try to read them. I'll open an issue.