### PR TITLE
Fix skipvalue for maps and arrays

### DIFF
--- a/src/types/arrays.jl
+++ b/src/types/arrays.jl
@@ -97,14 +97,18 @@ end
 
 function skipvalue(B::Binary, AT::ArrayType, ::Type{A}, buf, pos, buflen, opts) where {A <: AbstractVector{T}} where {T}
     while true
+        # read the count of elements in the block
         len, pos = readvalue(B, long, Int, buf, pos, buflen, opts)
         if len == 0
+            # no more elements: we are done
             break
         elseif len < 0
+            # the block includes its size in bytes: read it and skip that much
             sz, pos = readvalue(B, long, Int, buf, pos, buflen, opts)
             pos += sz
         else
-            for i = 1:-len
+            # skip each element in the block individually
+            for i = 1:len
                 pos = skipvalue(B, AT.items, T, buf, pos, buflen, opts)
             end
         end

--- a/src/types/maps.jl
+++ b/src/types/maps.jl
@@ -73,14 +73,18 @@ end
 
 function skipvalue(B::Binary, MT::MapType, ::Type{A}, buf, pos, buflen, opts) where {A <: AbstractDict{K, V}} where {K, V}
     while true
+        # read the count of elements in the block
         len, pos = readvalue(B, long, Int, buf, pos, buflen, opts)
         if len == 0
+            # no more elements: we are done
             break
         elseif len < 0
+            # the block includes its size in bytes: read it and skip that much
             sz, pos = readvalue(B, long, Int, buf, pos, buflen, opts)
             pos += sz
         else
-            for i = 1:-len
+            # skip each element in the block individually
+            for i = 1:len
                 pos = skipvalue(B, string, K, buf, pos, buflen, opts)
                 pos = skipvalue(B, MT.values, V, buf, pos, buflen, opts)
             end


### PR DESCRIPTION
Replaces #5. Renamed branch.

I discovered these bugs trying to read pre-written object files.